### PR TITLE
EPMRPP-104317 || add resource get log attachments

### DIFF
--- a/internal/reportportal/server.go
+++ b/internal/reportportal/server.go
@@ -48,6 +48,7 @@ func NewServer(
 	s.AddTool(testItems.toolGetTestItemById())
 	s.AddTool(testItems.toolListTestItemsByFilter())
 	s.AddResourceTemplate(testItems.resourceTestItem())
+	s.AddResourceTemplate(testItems.resourceTestItemAttachment())
 
 	prompts, err := readPrompts(promptFiles, "prompts")
 	if err != nil {


### PR DESCRIPTION
Add a new MCP resource, which provides the opportunity to retrieve files attached to test logs by their attachment ID