### PR TITLE
EPMRPP-107619 || MCP Server. GA4. Change user custom id format

### DIFF
--- a/internal/reportportal/server.go
+++ b/internal/reportportal/server.go
@@ -40,7 +40,8 @@ func NewServer(
 	var analytics *Analytics
 	if analyticsOn {
 		var err error
-		analytics, err = NewAnalytics(userID, analyticsAPISecret)
+		// Pass RP API token for secure hashing as user identifier
+		analytics, err = NewAnalytics(userID, analyticsAPISecret, token)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to initialize analytics: %w", err)
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Analytics now uses a hashed ReportPortal API token as the analytics user identifier and exposes the hashed ID.

- **Refactor**
  - IDs are derived and stored in-memory from the RP token (no local user file). Initialization now requires an RP API token and logs clearer status flags when GA4 secret or RP token are missing.

- **Tests**
  - Updated tests cover RP token-driven ID generation, empty userID behavior, and missing-token scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->