### PR TITLE
EPMRPP-109356 || MCP Tools. Register new tools to the http server

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Create variables
         id: vars

--- a/.github/workflows/build-feature-image.yaml
+++ b/.github/workflows/build-feature-image.yaml
@@ -19,7 +19,7 @@ jobs:
     if: (!startsWith(github.head_ref, 'rc/') || !startsWith(github.head_ref, 'hotfix/') || !startsWith(github.head_ref, 'master') || !startsWith(github.head_ref, 'main'))
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Create variables
         id: vars

--- a/.github/workflows/build-rc-image.yaml
+++ b/.github/workflows/build-rc-image.yaml
@@ -13,7 +13,7 @@ jobs:
     # environment: rc
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Create variables
         id: vars

--- a/internal/reportportal/http_server.go
+++ b/internal/reportportal/http_server.go
@@ -160,6 +160,8 @@ func (hs *HTTPServer) initializeTools() error {
 	hs.mcpServer.AddTool(testItems.toolGetTestItemLogsByFilter())
 	hs.mcpServer.AddTool(testItems.toolGetTestItemAttachment())
 	hs.mcpServer.AddTool(testItems.toolGetTestSuitesByFilter())
+	hs.mcpServer.AddTool(testItems.toolGetProjectDefectTypes())
+	hs.mcpServer.AddTool(testItems.toolUpdateDefectTypeForTestItems())
 
 	hs.mcpServer.AddResourceTemplate(testItems.resourceTestItem())
 


### PR DESCRIPTION
This PR adds two defect type management tools to the HTTP server implementation, bringing it into parity with the stdio-based MCP server. The tools allow users to retrieve project defect types and update defect types for test items.

Registers toolGetProjectDefectTypes() to retrieve all defect types for a specific project
Registers toolUpdateDefectTypeForTestItems() to update defect types for test items